### PR TITLE
[patch] Hoping the slack message will render a bit better with this

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function run() {
     // otherwise update the title, and make a comment.
     return Promise.all([
       updatePRTitle(client, changeType),
-      createPRCommentOnce(client, `After merging this PR, https://github.com/${ref.owner}/${ref.repo} will be version \`${nextVersion}\`. Note this may no longer be correct if another PR is merged.`),
+      createPRCommentOnce(client, `After merging this PR, [${ref.repo}](https://github.com/${ref.owner}/${ref.repo}) will be version \`${nextVersion}\`. Note this may no longer be correct if another PR is merged.`),
     ]);
   } else {
     await createPRCommentOnce(client, "Failed to identify a valid changetype for this pull request. Please specify either `[major]`, `[minor]`, or `[patch]` in the PR title.");


### PR DESCRIPTION
Not sure how this will go, but I'm hoping to make the link in the Slack payload render properly like it did with the old Github slack bot. It looks like this atm:

![image](https://user-images.githubusercontent.com/278134/115811647-6d5c8780-a433-11eb-86b8-d1f8e2c38db3.png)

I guess this will depend on whether github sends slack alerts with markdown turned on.