### PR TITLE
[patch] Added "notag" label for skipping tag creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automatically tags commits on master after merging a pull request. This action w
 
 ## Usage
 
-After activating the action, flag your pull requests or commits using any of `[major]`, `[minor]`, `[patch]`, `#major`, `#minor`, `#patch`.
+After activating the action, flag your pull requests or commits using any of `[major]`, `[minor]`, `[patch]`, `[notag]`, `#major`, `#minor`, `#patch`, `#notag`.
 
 The easiest way to use this action is to put the change type in the PR title.
 
@@ -15,6 +15,13 @@ The action will identify the changetype by looking for any of the above strings.
 
 After identifying a change type, the action will update the PR title to have the tag at the front. After this has occurred, the best way
 to flag a new change type (if you change your mind, for example) is to update the PR title.
+
+
+## Please Note
+
+Projects that use `merge-tag-action` in their workflow can opt-out of automatic git tag creation after a PR merge by using the following labels in their PR title or body: `[notag]` or `#notag`.
+
+
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function run() {
   } else if(changeType === "notag") {
     return Promise.all([
       updatePRTitle(client, changeType),
-      createPRCommentOnce(client, "`[notag]` detected. A new git tag will not be created when this PR is merged.");
+      createPRCommentOnce(client, "`[notag]` detected. A new git tag will not be created when this PR is merged."),
     ]);
   } else {
     await createPRCommentOnce(client, "Failed to identify a valid changetype for this pull request. Please specify either `[major]`, `[minor]`, `[patch]` or `[notag]` in the PR title.");

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ const semver = require('semver');
 const MAJOR_RE = /#major|\[\s?major\s?\]/gi
 const MINOR_RE = /#minor|\[\s?minor\s?\]/gi
 const PATCH_RE = /#patch|\[\s?patch\s?\]/gi
+const NOTAG_RE = /#notag|\[\s?notag\s?\]/gi
 
 async function run() {
   const client = new github.GitHub(core.getInput('repo-token'));
   const ref = getPullRef();
 
   const changeType = await getChangeTypeForContext(client);
-  if (changeType !== "") {
+  if (changeType !== "" changeType !== "notag") {
     const nextVersion = await getNewVersionTag(changeType);
     // if just merged, tag and release
     if (github.context.payload.action === "closed" && github.context.payload.pull_request.merged === true) {
@@ -25,8 +26,13 @@ async function run() {
       updatePRTitle(client, changeType),
       createPRCommentOnce(client, `After merging this PR, [${ref.repo}](https://github.com/${ref.owner}/${ref.repo}) will be version \`${nextVersion}\`. Note this may no longer be correct if another PR is merged.`),
     ]);
+  } else if(changeType === "notag") {
+    return Promise.all([
+      updatePRTitle(client, changeType),
+      createPRCommentOnce(client, "`[notag]` detected. A new git tag will not be created when this PR is merged.");
+    ]);
   } else {
-    await createPRCommentOnce(client, "Failed to identify a valid changetype for this pull request. Please specify either `[major]`, `[minor]`, or `[patch]` in the PR title.");
+    await createPRCommentOnce(client, "Failed to identify a valid changetype for this pull request. Please specify either `[major]`, `[minor]`, `[patch]` or `[notag]` in the PR title.");
     throw new Error("Failed to identify a valid change type.");
   }
 }
@@ -38,6 +44,7 @@ function updatePRTitle(client, changeType) {
   title = title.replace(MAJOR_RE, '');
   title = title.replace(MINOR_RE, '');
   title = title.replace(PATCH_RE, '');
+  title = title.replace(NOTAG_RE, '');
   // prepend the new tag
   title = `[${changeType}] ${title.trim()}`;
 
@@ -200,6 +207,10 @@ function getChangeTypeForString(string) {
   const patch = countOccurrences(string, PATCH_RE);
   if (patch > 0) {
     return "patch"
+  }
+  const notag = countOccurrences(string, NOTAG_RE);
+  if (notag > 0) {
+    return "notag"
   }
 
   return ""

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ async function run() {
   const ref = getPullRef();
 
   const changeType = await getChangeTypeForContext(client);
-  if (changeType !== "" changeType !== "notag") {
+  if (changeType !== "" && changeType !== "notag") {
     const nextVersion = await getNewVersionTag(changeType);
     // if just merged, tag and release
     if (github.context.payload.action === "closed" && github.context.payload.pull_request.merged === true) {


### PR DESCRIPTION
This change allows PR's to be marked with `[notag]` to avoid automatic tag creation when a tag is not required.

A typical example of where the `[notag]` label might be useful is when updating a project's helm chart configuration.

Examples of this change in action can be seen in the PRs of this temporary project that I used for testing: https://github.com/mx51/tmp-notag-testing/pulls?q=is%3Apr+is%3Aclosed

The idea for this `merge-tag-action` feature was raised during a recent devops champions discussion (cc @byatesrae).