### PR TITLE
[patch] BAU-add-version-output

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ async function run() {
   const changeType = await getChangeTypeForContext(client);
   if (changeType !== "" && changeType !== "notag") {
     const nextVersion = await getNewVersionTag(changeType);
+    core.setOutput('NEXT_VERSION', `${nextVersion}`);
     // if just merged, tag and release
     if (github.context.payload.action === "closed" && github.context.payload.pull_request.merged === true) {
       return createAnnotatedTag(client, nextVersion).then(() => {


### PR DESCRIPTION
want to publish the next-version value as an output.
this will enable subsequent action commands to import this value.