### PR TITLE
[minor] Add action outputs with version and tag status

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,11 @@ inputs:
   repo-token:
     description: "a github token for API access"
     required: true
+outputs:
+  version:
+    description: "next/tagged version"
+  tagged:
+    description: "whether version was tagged (on merge) or not"
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -15,10 +15,11 @@ async function run() {
   const changeType = await getChangeTypeForContext(client);
   if (changeType !== "" && changeType !== "notag") {
     const nextVersion = await getNewVersionTag(changeType);
-    core.setOutput('NEXT_VERSION', `${nextVersion}`);
+    core.setOutput('version', `${nextVersion}`);
     // if just merged, tag and release
     if (github.context.payload.action === "closed" && github.context.payload.pull_request.merged === true) {
       return createAnnotatedTag(client, nextVersion).then(() => {
+        core.setOutput('tagged', true);
         return createPRCommentOnce(client, `Merged and tagged as \`${nextVersion}\`.`)
       });
     }


### PR DESCRIPTION
Allow chaining after tagging, since `on.tags` doesn't trigger https://github.com/orgs/community/discussions/27028